### PR TITLE
Deleting insecure/unnecessary agent protocols

### DIFF
--- a/casc.yml
+++ b/casc.yml
@@ -4,10 +4,6 @@ plugins:
     url: "https://updates.jenkins.io/update-center.json"
 jenkins:
   agentProtocols:
-  - "CLI-connect"
-  - "CLI2-connect"
-  - "JNLP-connect"
-  - "JNLP2-connect"
   - "JNLP4-connect"
   - "Ping"
   authorizationStrategy:


### PR DESCRIPTION
For the moment, `JNLP4-connect` is required by the `kubernetes` plugin, though (as confirmed with @carlossg) we would like to be able to turn off the `slaveAgentPort` altogether and switch to a master-initiated connection, perhaps via `exec`.